### PR TITLE
Formalization audit (chapter 2): seven more statement-level fixes

### DIFF
--- a/PutnamLike/Set1/B5.lean
+++ b/PutnamLike/Set1/B5.lean
@@ -47,6 +47,6 @@ theorem putnam_like_set1_b5
     (n N : ℕ) (hn : n ≠ 0) (hN : N ≠ 0) (r : Fin n → ℝ) (hr : ∀ i, r i ∈ Set.Ioo 0 1)
     (m : Finset (Fin n) → ℝ) (hm : ∀ (S) (hS : S.Nonempty), m S = S.inf' hS r)
     (hm' : m ∅ = 0) :
-    ∑ S : Finset (Fin n), (- 1) ^ S.card * (m S) ^ (2 * N + (∑ i ∈ S, i.val) - 1 : ℝ)
-      / (N + (∑ i ∈ S, i.val)) ≤ 0 := by
+    ∑ S : Finset (Fin n), (- 1) ^ S.card * (m S) ^ (2 * N + (∑ i ∈ S, i.val) + S.card - 1 : ℝ)
+      / (N + (∑ i ∈ S, i.val) + S.card) ≤ 0 := by
   sorry

--- a/PutnamLike/Set1/B6.lean
+++ b/PutnamLike/Set1/B6.lean
@@ -34,7 +34,7 @@ in terms of $x_0, \alpha, \beta$.
 -/
 theorem putnam_like_set1_b6
     (x₀ β : ℕ) (α : ℝ) (hα : 0 < α) (hα' : Irrational α)
-    (hαβ : β - α ∈ Set.Ioo 0 1) (hα : ∃ (n : ℕ), α ^ 2 = n)
+    (hαβ : β - α ∈ Set.Ioo 0 1) (hα'' : ∃ (n : ℕ), α ^ 2 = n)
     (x : ℕ → ℕ) (hx₀ : x 0 = x₀) (hx_rec : ∀ n, x (n + 1) = β * x n + ⌊α * x n⌋) :
     letI lim : Filter ℝ := putnam_like_set1_b6_solution x₀ α β
     Filter.atTop.Tendsto (fun n ↦ x n / (α + β) ^ n) lim ∧

--- a/PutnamLike/Set4/A3.lean
+++ b/PutnamLike/Set4/A3.lean
@@ -38,7 +38,8 @@ theorem putnam_like_set4_a3
       Module.End.HasEigenvalue A.toLin' μ → IsSquare μ)
     (PosMinors : ∀ n p, Matrix (Fin n) (Fin n) (ZMod p) → Prop)
     (PosMinors_def : ∀ p n A, PosMinors n p A ↔
-      ∀ m, ∀ ι : Fin m ↪o Fin n, IsSquare (A.submatrix ι ι).det) :
+      ∀ k (hk : k ≤ n),
+        IsSquare (A.submatrix (Fin.castLEOrderEmb hk) (Fin.castLEOrderEmb hk)).det) :
     let (IsTrue, leftImpl, rightImpl) := putnam_like_set4_a3_solution
     (IsTrue ↔ ∀ n ≥ 2, ∀ p A, p.Prime → Good n p A → PosEvalues n p A = PosMinors n p A) ∧
       (leftImpl ↔ ∀ n ≥ 2, ∀ p A, p.Prime → Good n p A → PosEvalues n p A → PosMinors n p A) ∧

--- a/PutnamLike/Set4/B1.lean
+++ b/PutnamLike/Set4/B1.lean
@@ -31,7 +31,7 @@ $k^2 P\left( \frac{1}{k} \right) = P_2(k)$ for all $k \in \mathbb{Z}$?
 $\frac{1}{k} Q \left( \frac{1}{k} \right) = \frac{P_1(k)}{P_2(k)}$ for all $k \in \mathbb{Z}$?
 -/
 theorem putnam_like_set4_b1 (P1 P2 : ℝ[X]) (hP1 : P1.degree = 1) (hP2 : P2.degree = 2)
-    (hP2 : ∀ n : ℤ, P2.eval (n : ℝ) ≠ 0) :
+    (hP2nz : ∀ n : ℤ, P2.eval (n : ℝ) ≠ 0) :
     ((∃ P : ℝ[X], ∀ k : ℤ, k ≠ 0 → k ^ 2 * P.eval (1 / k : ℝ) = P2.eval (k : ℝ))
       ↔ putnam_like_set4_b1_solution.1) ∧
     ((∃ Q : ℝ[X], ∀ k : ℤ, k ≠ 0 → (1 / k) * Q.eval (1 / k : ℝ) = P1.eval (k : ℝ) / P2.eval (k : ℝ))

--- a/PutnamLike/Set4/B4.lean
+++ b/PutnamLike/Set4/B4.lean
@@ -28,4 +28,4 @@ for any $k \geq 1$, where $\omega_n$ denotes the surface area of the $(n-1)$-dim
 theorem putnam_like_set4_b4 (n k : ℕ) [NeZero n] (hk : 1 ≤ k) :
     letI normalisationFactor := (volume <| Metric.closedBall (0 : EuclideanSpace ℝ (Fin n)) 1).toReal / 2 ^ n
     (μH[n-1] (Metric.sphere (0 : EuclideanSpace ℝ (Fin n)) 1)).toReal / normalisationFactor / (n ^ k * (2 * k + n))
-      ≤ ∫ x in Metric.closedBall (0 : EuclideanSpace ℝ (Fin n)) 1, |x 0| ^ k := by sorry
+      ≤ ∫ x in Metric.closedBall (0 : EuclideanSpace ℝ (Fin n)) 1, |x 0| ^ (2 * k) := by sorry

--- a/PutnamLike/Set6/A1.lean
+++ b/PutnamLike/Set6/A1.lean
@@ -27,8 +27,8 @@ The roots of $x^3 + a x^2 + b x + c = 0$ are $\alpha,$ $\beta$
 and $\gamma$. Find the cubic polynomial whose roots are
 $\alpha^2$, $\beta^2$, $\gamma^2$.
 -/
-theorem putnam_like_set6_a1 (α β γ : ℝ) (P : ℝ[X])
-    (hP : P.roots = {α, β, γ}) :
+theorem putnam_like_set6_a1 (α β γ : ℝ) (P : ℝ[X]) (hPm : P.Monic)
+    (hPd : P.natDegree = 3) (hP : P.roots = {α, β, γ}) :
     letI Q := putnam_like_set6_a1_solution (P.coeff 2) (P.coeff 1) (P.coeff 0)
     Q.roots = {α ^ 2, β ^ 2, γ ^ 2} := by
   sorry

--- a/PutnamLike/Set6/A6.lean
+++ b/PutnamLike/Set6/A6.lean
@@ -37,7 +37,7 @@ def Convex2025GonSet : Set (Set (EuclideanSpace ℝ (Fin 2))) :=
 /-- The predicate that a set is a $2025$-gon whose vertex angles are obtuse. -/
 def IsConvexObtuse2025GonSet (S : Fin 2025 → EuclideanSpace ℝ (Fin 2)) : Prop :=
   ∃ P : Fin 2025 → EuclideanSpace ℝ (Fin 2), Set.range S = Set.range P ∧ (∀ i j k, i < j → j < k → (∡ (P i) (P j) (P k)).sign = 1) ∧
-    (∀ i, btw (Real.Angle.coe 0) (∡ (P i) (P <| i + 1) (P <| i + 2)) (Real.Angle.coe <| π / 2))
+    (∀ i, btw (Real.Angle.coe <| π / 2) (∡ (P i) (P <| i + 1) (P <| i + 2)) (Real.Angle.coe π))
 
 /--
 Suppose that $P_1, P_2, \dots, P_{2025}$ are $2025$ randomly,

--- a/PutnamLike/Set7/A3.lean
+++ b/PutnamLike/Set7/A3.lean
@@ -26,5 +26,5 @@ $$
 -/
 theorem putnam_like_set7_a3 {n : ℕ} (hn : 2 ≤ n) (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
     (σ : Equiv.Perm (Fin n)) :
-    (∏ i, a i ^ a (σ i) / ∏ i, (a i) ! : ℚ) < (∑ i, a i) ^ (∑ i, a i) / (∑ i, a i) ! := by
+    ((∏ i, a i ^ a (σ i) : ℚ) / ∏ i, (a i) !) < (∑ i, a i) ^ (∑ i, a i) / (∑ i, a i) ! := by
   sorry


### PR DESCRIPTION
## Summary

Seven more places where the Lean formalization in `PutnamLike/`
disagrees with the natural-language problem. Same approach as the
companion audit PR (#3): produced by a parallel-subagent sweep over
all 96 files and re-verified by a skeptical second pass.

This branch was rebased onto current master after the recent fixes
landed there. Two of the original chapter-2 candidates — `Set3/A6`
and the sign-error half of `Set6/A1` — are already addressed on
master (commits 9cb504d / 1279205) and dropped here. Seven survive.

## The seven findings

| File | Category | What changes |
|---|---|---|
| `PutnamLike/Set1/B5.lean` | off-by-one | exponent and denominator add `+ S.card` to convert 0-based `Fin n` indices to the informal 1-based indices |
| `PutnamLike/Set1/B6.lean` | duplicate binder | second `hα` shadows the first; rename to `hα''` |
| `PutnamLike/Set4/A3.lean` | leading vs all principal minors | restrict `∀ ι : Fin m ↪o Fin n` to the canonical `Fin.castLEOrderEmb` family |
| `PutnamLike/Set4/B1.lean` | duplicate binder | second `hP2` shadows the first; rename to `hP2nz` |
| `PutnamLike/Set4/B4.lean` | wrong exponent | `|x 0| ^ k` → `|x 0| ^ (2 * k)` to match informal `|x_1|^(2k)` and the stated bound |
| `PutnamLike/Set6/A1.lean` | missing hypotheses | now that the sign error is fixed on master, the theorem still needs `P.Monic` and `P.natDegree = 3` |
| `PutnamLike/Set6/A6.lean` | acute vs obtuse | `btw 0 θ (π/2)` pins `θ ∈ [0, π/2]` (acute); replace with `btw (π/2) θ π` to match the predicate's own name `IsConvexObtuse…` |
| `PutnamLike/Set7/A3.lean` | operator precedence | `∏` body absorbs the `/`; add explicit parentheses so the LHS is `(∏ i, num) / (∏ i, denom)` rather than `∏ i, (num / denom)` |

## Per-finding rationale

### `Set1/B5` — off-by-one on `Fin` indices

Informal sum runs over `1 ≤ i_1 < … < i_k ≤ n` — **1-based**.
`S : Finset (Fin n)` has `i.val ∈ {0, …, n-1}`, so for each `i ∈ S`,
`i.val + 1` is the corresponding informal `i_j`. The informal
`i_1 + … + i_k` is therefore `(∑ i ∈ S, i.val) + S.card`, and both
the exponent `2N + (∑ i_j) − 1` and the denominator `N + (∑ i_j)`
are short by `S.card`. The recent commit 7c6d1eb adds
`(hN : N ≠ 0)` (preventing `0^(-1)` at the empty-`S` slice) but the
underlying 1-based-vs-0-based mismatch remains.

### `Set1/B6` — duplicate `hα` binder

```
(hα : 0 < α) (hα' : Irrational α) (hαβ : β - α ∈ Set.Ioo 0 1)
(hα : ∃ (n : ℕ), α ^ 2 = n)
```
Two binders named `hα`; the second shadows the first so `0 < α` is
not directly accessible by name. (Note this is the same shadowing
class as the recently-merged `Set1/B3` `hf` rename.)

### `Set4/A3` — leading vs all principal minors

```lean
(PosMinors_def : ∀ p n A, PosMinors n p A ↔
  ∀ m, ∀ ι : Fin m ↪o Fin n, IsSquare (A.submatrix ι ι).det)
```

`∀ ι : Fin m ↪o Fin n` quantifies over every order embedding, i.e.
every principal minor. The docstring asks for *leading* principal
minors (top-left `k × k` submatrices for `k = 1, …, n`).
Classically:
```
all principal minors ≥ 0  ⇔  positive semi-definite
all leading minors    > 0  ⇔  positive definite (Sylvester)
```
so the two conditions are inequivalent even in the real case — the
question of which holds for symmetric matrices over `ZMod p` is
sensitive to this. Restrict to the canonical
`Fin.castLEOrderEmb hk : Fin k ↪o Fin n` family.

### `Set4/B1` — duplicate `hP2` binder

```
(hP1 : P1.degree = 1) (hP2 : P2.degree = 2)
(hP2 : ∀ n : ℤ, P2.eval (n : ℝ) ≠ 0)
```
Same shadowing class as `Set1/B6`. Rename the second to `hP2nz`.

### `Set4/B4` — integrand exponent off by factor 2

Informal: `∫_{B(0,1)} |x_1|^(2k) dx ≥ ω_n / (n^k · (2k + n))`. Lean
integrand is `|x 0| ^ k`. The stated bound matches the `2k`-form,
since `∫_0^1 r^(2k+n-1) dr = 1/(2k+n)` is what the spherical
change of variables produces. With exponent `k` the integral on the
unit ball is **larger** (since `|x_1| ≤ 1` makes `|x_1|^k ≥
|x_1|^(2k)`), so the inequality is weaker but still holds — the
formalization no longer encodes the intended problem.

### `Set6/A1` — missing monic / degree hypotheses

The sign errors in the solution polynomial were fixed in commit
1279205. The theorem still needs:
```lean
theorem putnam_like_set6_a1 (α β γ : ℝ) (P : ℝ[X]) (hPm : P.Monic)
    (hPd : P.natDegree = 3) (hP : P.roots = {α, β, γ})
```
Without these, `P` could be `2·(X − α)·(X − β)·(X − γ)` (non-monic)
or `(X − α)·(X − β)·(X − γ)·(X² + 1)` (degree 5, splits over ℝ
only at three roots), and the Vieta relations on `P.coeff 0/1/2`
no longer correspond to α, β, γ.

### `Set6/A6` — predicate checks acute, not obtuse

```lean
(∀ i, btw (Real.Angle.coe 0) (∡ (P i) (P (i+1)) (P (i+2)))
          (Real.Angle.coe (π / 2)))
```

`btw 0 θ (π/2)` (under the `Real.Angle = ℝ/(2π·ℤ)`'s `CircularOrder`,
which unfolds to "θ's representative in `[0, 2π)` lies in
`[0, π/2]`") captures the **acute** range. The docstring and the
predicate name (`IsConvexObtuse2025GonSet`) both claim obtuse
angles. Replace with:
```lean
(∀ i, btw (Real.Angle.coe (π/2)) (∡ (P i) (P (i+1)) (P (i+2)))
          (Real.Angle.coe π))
```

### `Set7/A3` — `∏` body absorbs the division

```
∏ i, a i ^ a (σ i) / ∏ i, (a i) !
```
The `∏` notation parses its body at precedence 67 and `/` is
`infixl 70`, so the body extends through `/` to the second `∏`.
The LHS therefore evaluates to
```
∏ i, ( a i ^ a (σ i) / (∏ j, (a j) !) )
  = (∏ i, a i ^ a (σ i)) / (∏ j, (a j) !)^n
```
i.e. off by `(∏ j, (a j) !)^(n − 1)` from the intended
`(∏ i, a i ^ a (σ i)) / (∏ j, (a j) !)`. (Concrete witness at
`n = 2, a = ![2, 3], σ = id`: parsed LHS evaluates to `3/4`, the
intended expression is `9`; ratio `12 = (2! · 3!)^1`.) Same parsing
class as the recently-fixed `Set5/A6` `⨅`. Add explicit parentheses.

## Methodology

1. **Parallel sweep.** Eight subagents, one per `Set<N>/`, each
   reviewed 12 problems against the docstring for a fixed list of
   bug categories.
2. **Skeptical second-pass.** Three more subagents took the
   first-pass verdicts and were asked to **disprove** each claim,
   either confirming with fresh evidence or challenging.
3. **Compile check.** All seven edits compile warning-free on the
   current master's toolchain (Lean v4.27.0).

## How to review

```bash
git fetch origin pull/<N>/head:pr-audit-ch2
git checkout pr-audit-ch2
lake exe cache get
lake build PutnamLike.Set1.B5 PutnamLike.Set1.B6 PutnamLike.Set4.A3 \
           PutnamLike.Set4.B1 PutnamLike.Set4.B4 PutnamLike.Set6.A1 \
           PutnamLike.Set6.A6 PutnamLike.Set7.A3
```

Each finding is independent and can be accepted or rejected on its
own.